### PR TITLE
KN-9892: Update swiftlint.yml

### DIFF
--- a/Project Templates/iTomych-Swift.xctemplate/swiftlint.yml
+++ b/Project Templates/iTomych-Swift.xctemplate/swiftlint.yml
@@ -3,9 +3,7 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Carthage
   - AutomationTools
 
-line_length:
-  warning: 200
-  ignores_comments: true
+line_length: 300
 
 file_length:
   warning: 500
@@ -34,11 +32,11 @@ disabled_rules: # rule identifiers to exclude from running
   - identifier_name
   - todo                        # disabled till API integration phase
   - unused_closure_parameter    # disabled till API integration phase
+  - nesting
+  - private_over_fileprivate
 
 opt_in_rules:
   - empty_count
   - empty_string
   - explicit_init
   - implicit_return
-  - overridden_super_call
-  - prohibited_super_call


### PR DESCRIPTION
- `line_length`:
    1.  Behaves oddly: generates an **error** instead of **warning** even if the line of code satisfies the requirement. So i've simplified the rule to the basic version which behaves as expected.
    2.  Updated number of lines, since even some of `UIKit` delegate methods take more than 200 lines.
-  `nesting`: can be discussed. As for Keen, we have `Settings.Keys` with nested enums which represent logical groups of keys for easier use. We could move `Keys` outside `Settings`, but those keys doesn't make any sense outside of `Settings` struct. On the other hand, combining all keys into one enum will be more messy.
-  `private_over_fileprivate`. I'd suggest to remove this rule. Say you have a helper class or struct that is used only inside the main class of particular file. It doesn't make any sense outside of this class and is not used anywhere else.